### PR TITLE
🐛 Fix options of `jsdoc/require jsdoc`

### DIFF
--- a/rules/core.js
+++ b/rules/core.js
@@ -337,7 +337,7 @@ module.exports = {
         exemptEmptyConstructors: true,
         exemptEmptyFunctions: false,
         fixerMessage: '',
-        minLineCount: 'undefined',
+        minLineCount: undefined,
         publicOnly: false,
         require: {
           ArrowFunctionExpression: false,


### PR DESCRIPTION
## Why

* Close #14
