### PR TITLE
🐛 Fix options of `jsdoc/multiline-blocks`

### DIFF
--- a/rules/core.js
+++ b/rules/core.js
@@ -170,7 +170,7 @@ module.exports = {
         ],
         noFinalLineText: true,
         noMultilineBlocks: false,
-        noSingleLineBlocks: true,
+        noSingleLineBlocks: false,
         noZeroLineText: true,
         singleLineTags: [
           'lends',

--- a/rules/core.js
+++ b/rules/core.js
@@ -175,8 +175,6 @@ module.exports = {
         singleLineTags: [
           'lends',
           'type',
-          'inheritdoc',
-          'override',
         ],
       },
     ],


### PR DESCRIPTION
## Why

* Close #16
